### PR TITLE
fix defer_mail $reason.

### DIFF
--- a/lib/Mail/Milter/Authentication/Handler/RSpamD.pm
+++ b/lib/Mail/Milter/Authentication/Handler/RSpamD.pm
@@ -232,7 +232,7 @@ sub eom_callback {
         $self->quarantine_mail( 'Quarantined due to SPAM policy' );
     }
     if ( $action eq 'soft_reject' ) {
-        $self->defer_mail( 'SPAM policy violation, come back later' );
+        $self->defer_mail( '450 SPAM policy violation, come back later' );
     }
 
     $self->prepend_header( 'X-Spam-score',  sprintf( '%.02f',  $spam->{'score'} ) );


### PR DESCRIPTION
ERROR: EOM callback error Can't locate object method "loginfo" via package "Mail::Milter::Authentication::Handler::RSpamD" at /usr/local/lib/perl5/site_perl/Mail/Milter/Authentication/Handler.pm line 1330, <$read> line 5858.

loginfo method does not exist in Mail::Milter::Authentication::Handler.
It exists in Mail::Milter::Authentication.
calling method may need to be modified.